### PR TITLE
Remove unused build-breaking method `setSDKRoot` definition

### DIFF
--- a/DebugAdapter/ExternalHeaders/lldb/API/SBPlatform.h
+++ b/DebugAdapter/ExternalHeaders/lldb/API/SBPlatform.h
@@ -137,8 +137,6 @@ public:
 
   uint32_t GetOSUpdateVersion();
 
-  void SetSDKRoot(const char *sysroot);
-
   SBError Put(SBFileSpec &src, SBFileSpec &dst);
 
   SBError Get(SBFileSpec &src, SBFileSpec &dst);

--- a/DebugAdapter/Sources/LLDBObjC/LLDBPlatform.mm
+++ b/DebugAdapter/Sources/LLDBObjC/LLDBPlatform.mm
@@ -106,10 +106,6 @@
     _platform.DisconnectRemote();
 }
 
-- (void)setSDKRoot:(NSString *)sdkRoot {
-    _platform.SetSDKRoot(sdkRoot.UTF8String);
-}
-
 - (mode_t)filePermissionsForPath:(NSString *)path {
     return _platform.GetFilePermissions(path.UTF8String);
 }

--- a/DebugAdapter/Sources/LLDBObjC/include/LLDBPlatform.h
+++ b/DebugAdapter/Sources/LLDBObjC/include/LLDBPlatform.h
@@ -31,8 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)connectRemote:(LLDBPlatformConnectOptions *)options error:(NSError **)outError;
 - (void)disconnectRemote;
 
-- (void)setSDKRoot:(NSString *)sdkRoot;
-
 - (mode_t)filePermissionsForPath:(NSString *)path;
 - (BOOL)setFilePermissions:(mode_t)mode forPath:(NSString *)path error:(NSError **)outError;
 


### PR DESCRIPTION
`setSDKRoot` doesn’t seem to be used anywhere and isn’t defined in the LLDB framework that I’m seeing (in Xcode 14 SharedFrameworks/LLDB.framework), and is causing a link error when I attempt to build this branch.