### PR TITLE
Escaped Character highlighting support inside string literals.

### DIFF
--- a/Icarus.novaextension/Queries/c/highlights.scm
+++ b/Icarus.novaextension/Queries/c/highlights.scm
@@ -65,6 +65,7 @@
 (null) @value.null
 (number_literal) @value.number
 (char_literal) @value.number
+(escape_sequence) @value.number
 [
   (true)
   (false)

--- a/Icarus.novaextension/Queries/cpp/highlights.scm
+++ b/Icarus.novaextension/Queries/cpp/highlights.scm
@@ -62,11 +62,11 @@
 
 ; Types
 
-(qualified_identifier 
+(qualified_identifier
   scope: (namespace_identifier) @identifier.type)
 
 (type_descriptor
-  (qualified_identifier 
+  (qualified_identifier
     name: (type_identifier) @identifier.type))
 
 ((namespace_identifier) @identifier.type
@@ -184,6 +184,7 @@
 (string_literal) @string
 (raw_string_literal) @string
 (char_literal) @value.number
+(escape_sequence) @value.number
 
 ; Declarations
 

--- a/Icarus.novaextension/Queries/objc/highlights.scm
+++ b/Icarus.novaextension/Queries/objc/highlights.scm
@@ -184,7 +184,7 @@
   (module_string)
 ] @string
 
-(escape_sequence) @string.escape
+(escape_sequence) @value.number
 
 (null) @value.null
 (nil) @value.null
@@ -290,7 +290,7 @@
   function: (identifier) @identifier.function)
 (function_declarator
   declarator: (identifier) @identifier.function)
-(selector_expression 
+(selector_expression
   name: (identifier) @identifier.function)
 ; (method_declaration
 ;   selector: (identifier) @identifier.function)
@@ -349,17 +349,17 @@
 ;; Parameters
 ; (parameter_declaration
 ;   declarator: (identifier) @identifier.variable.parameter)
-; 
+;
 ; (parameter_declaration
 ;   declarator: (pointer_declarator) @identifier.variable.parameter)
-; 
+;
 ; (parameter_declaration
 ;   declarator: (pointer_declarator
 ;     declarator: (identifier) @identifier.variable.parameter))
 
 ; (for_in_statement
 ;   loop: (identifier) @identifier.variable)
-; 
+;
 ; (dictionary_expression
 ;   key: (_expression) @identifier.variable)
 ; (dictionary_expression

--- a/Icarus.novaextension/Queries/swift/highlights.scm
+++ b/Icarus.novaextension/Queries/swift/highlights.scm
@@ -114,7 +114,7 @@
 
 ; String literals
 (line_str_text) @string
-(str_escaped_char) @string
+(str_escaped_char) @value.number
 (multi_line_str_text) @string
 (raw_str_part) @string
 (raw_str_end_part) @string
@@ -167,7 +167,7 @@
 
  "..<"
  "..."
- 
+
  (bang)
 ] @operator
 


### PR DESCRIPTION
Hello! 
This pull request adds highlighting support for escape characters. Currently Nova does not have a specific theming selector for these characters like the `regex.escaped`, or the `string.escape` that was written in `objc/highlights.scm`

I followed your convention of using `@value.number` for `char` values, so that the theming is consistent across.
- I have seen this in other editors and it's extremely beneficial to relieve eye strain 😵‍💫 , esp in `printf` style functions!
- I did the same for `Objective C`, `swift` and `C`. 

PS. I am very new to C family programming language and barely touched the surface with C++. I gave it a shot myself in all the languages and it seem to work fine. However I found a parsing bug 🐞 while I was testing, very likely due to core Nova, Unrelated to this extension or tree-sitter 🌳 and I will raise it via the form on Nova.app. Other than that it worked as expected on my side! 😊 

<img width="460" alt="Screenshot 2023-09-30 at 11 38 08" src="https://github.com/panicinc/icarus/assets/11975985/8ae75f32-9ca8-4292-a9c7-74d99194e94f">

👇👇👇👇👇👇

<img width="460" alt="Screenshot 2023-09-30 at 11 38 22" src="https://github.com/panicinc/icarus/assets/11975985/eafacfb0-c31c-44e1-87b0-611ccee57938">

